### PR TITLE
Remove json render from Calendar#index

### DIFF
--- a/tutorial/05-add-ms-graph.md
+++ b/tutorial/05-add-ms-graph.md
@@ -91,7 +91,6 @@ class CalendarController < ApplicationController
 
   def index
     @events = get_calendar_events access_token || []
-    render json: @events
   rescue RuntimeError => e
     @errors = [
       {


### PR DESCRIPTION
The `render json: @events` line will render a json file rather than the erb view created in the next step. Removing the render json line will result in the erb view rendering as expected.